### PR TITLE
Add .NET 9 Minimal API Sonar proxy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+# C# coding conventions
+csharp_new_line_before_open_brace = all
+csharp_indent_case_contents = true
+
+dotnet_style_qualification_for_field = false:suggestion
+
+dotnet_diagnostic.CS8618.severity = warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+      - name: Test
+        run: dotnet test --no-build --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+bin/
+obj/
+logs/
+*.user
+*.swp
+.dotnet/
+dotnet-install.sh
+TestResults/

--- a/Api/Endpoints/AccountEndpoints.cs
+++ b/Api/Endpoints/AccountEndpoints.cs
@@ -1,0 +1,23 @@
+using MDUC_BE.Api.Filters;
+using MDUC_BE.Api.Models;
+using MDUC_BE.Application.Services;
+
+namespace MDUC_BE.Api.Endpoints;
+
+public static class AccountEndpoints
+{
+    public static RouteGroupBuilder MapAccountEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/account", async (CreateAccountRequest request, AccountService service) =>
+        {
+            var result = await service.CreateAsync(request);
+            return Results.Ok(result);
+        })
+        .AddEndpointFilter<ValidateCreateAccountFilter>()
+        .WithName("CreateAccount")
+        .WithSummary("Create account")
+        .WithOpenApi();
+
+        return group;
+    }
+}

--- a/Api/Endpoints/AddressEndpoints.cs
+++ b/Api/Endpoints/AddressEndpoints.cs
@@ -1,0 +1,22 @@
+using MDUC_BE.Api.Filters;
+using MDUC_BE.Application.Services;
+
+namespace MDUC_BE.Api.Endpoints;
+
+public static class AddressEndpoints
+{
+    public static RouteGroupBuilder MapAddressEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/addresses", async (string line1, AddressService service) =>
+        {
+            var addresses = await service.GetByLine1Async(line1);
+            return Results.Ok(addresses);
+        })
+        .AddEndpointFilter<ValidateAddressQueryFilter>()
+        .WithName("GetAddresses")
+        .WithSummary("Get serviceable addresses by line1")
+        .WithOpenApi();
+
+        return group;
+    }
+}

--- a/Api/Filters/ValidateAddressQueryFilter.cs
+++ b/Api/Filters/ValidateAddressQueryFilter.cs
@@ -1,0 +1,19 @@
+using MDUC_BE.Common.Errors;
+using MDUC_BE.Common.Models;
+
+namespace MDUC_BE.Api.Filters;
+
+public class ValidateAddressQueryFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var line1 = context.HttpContext.Request.Query["line1"].ToString();
+        if (string.IsNullOrWhiteSpace(line1) || line1.Length < 3)
+        {
+            var error = new ErrorResponse(context.HttpContext.TraceIdentifier, ApiErrorCode.Validation, "line1 must be at least 3 characters", null);
+            return Results.Json(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        return await next(context);
+    }
+}

--- a/Api/Filters/ValidateCreateAccountFilter.cs
+++ b/Api/Filters/ValidateCreateAccountFilter.cs
@@ -1,0 +1,20 @@
+using MDUC_BE.Api.Models;
+using MDUC_BE.Common.Errors;
+using MDUC_BE.Common.Models;
+
+namespace MDUC_BE.Api.Filters;
+
+public class ValidateCreateAccountFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var request = context.Arguments.FirstOrDefault(a => a is CreateAccountRequest) as CreateAccountRequest;
+        if (request is null || string.IsNullOrWhiteSpace(request.Name))
+        {
+            var error = new ErrorResponse(context.HttpContext.TraceIdentifier, ApiErrorCode.Validation, "Name is required", null);
+            return Results.Json(error, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        return await next(context);
+    }
+}

--- a/Api/Middleware/ApiKeyMiddleware.cs
+++ b/Api/Middleware/ApiKeyMiddleware.cs
@@ -1,0 +1,36 @@
+using MDUC_BE.Common.Errors;
+using MDUC_BE.Common.Models;
+
+namespace MDUC_BE.Api.Middleware;
+
+public class ApiKeyMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ApiKeyMiddleware> _logger;
+    private readonly string? _expectedKey;
+
+    public ApiKeyMiddleware(RequestDelegate next, IConfiguration configuration, ILogger<ApiKeyMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+        _expectedKey = configuration["PublicApiKey"];
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!string.IsNullOrEmpty(_expectedKey) && context.Request.Headers.TryGetValue("X-API-Key", out var provided) && provided == _expectedKey)
+        {
+            await _next(context);
+            return;
+        }
+
+        _logger.LogWarning("Invalid API key");
+        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+        await context.Response.WriteAsJsonAsync(new ErrorResponse(context.TraceIdentifier, ApiErrorCode.Unauthorized, "Invalid API key", null));
+    }
+}
+
+public static class ApiKeyMiddlewareExtensions
+{
+    public static IApplicationBuilder UseApiKey(this IApplicationBuilder app) => app.UseMiddleware<ApiKeyMiddleware>();
+}

--- a/Api/Middleware/ErrorHandlingMiddleware.cs
+++ b/Api/Middleware/ErrorHandlingMiddleware.cs
@@ -1,0 +1,36 @@
+using MDUC_BE.Common.Errors;
+using MDUC_BE.Common.Models;
+
+namespace MDUC_BE.Api.Middleware;
+
+public class ErrorHandlingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ErrorHandlingMiddleware> _logger;
+
+    public ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandlingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception");
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            var error = new ErrorResponse(context.TraceIdentifier, ApiErrorCode.Unexpected, "Unexpected error", null);
+            await context.Response.WriteAsJsonAsync(error);
+        }
+    }
+}
+
+public static class ErrorHandlingMiddlewareExtensions
+{
+    public static IApplicationBuilder UseGlobalErrorHandler(this IApplicationBuilder app) => app.UseMiddleware<ErrorHandlingMiddleware>();
+}

--- a/Api/Models/AddressDto.cs
+++ b/Api/Models/AddressDto.cs
@@ -1,0 +1,14 @@
+namespace MDUC_BE.Api.Models;
+
+public record AddressDto(
+    string Id,
+    string Line1,
+    string? Line2,
+    string City,
+    string? Subdivision,
+    string Zip,
+    string Country,
+    double? Latitude,
+    double? Longitude,
+    bool Serviceable,
+    string AddressableType);

--- a/Api/Models/CreateAccountDtos.cs
+++ b/Api/Models/CreateAccountDtos.cs
@@ -1,0 +1,16 @@
+namespace MDUC_BE.Api.Models;
+
+public record CreateAccountRequest(
+    string Name,
+    long AccountTypeId,
+    long AccountStatusId,
+    string? ServiceableAddressId,
+    string PrimaryContactName
+    // TODO: Adjust fields according to Sonar schema
+);
+
+public record CreateAccountResponse(
+    long Id,
+    string Name
+    // TODO: Include additional fields from Sonar response
+);

--- a/Application/Services/AccountService.cs
+++ b/Application/Services/AccountService.cs
@@ -1,0 +1,12 @@
+using MDUC_BE.Api.Models;
+using MDUC_BE.Infrastructure.GraphQL;
+
+namespace MDUC_BE.Application.Services;
+
+public class AccountService
+{
+    private readonly SonarGraphQLClient _client;
+    public AccountService(SonarGraphQLClient client) => _client = client;
+
+    public Task<CreateAccountResponse?> CreateAsync(CreateAccountRequest request, CancellationToken ct = default) => _client.CreateAccountAsync(request, ct);
+}

--- a/Application/Services/AddressService.cs
+++ b/Application/Services/AddressService.cs
@@ -1,0 +1,12 @@
+using MDUC_BE.Api.Models;
+using MDUC_BE.Infrastructure.GraphQL;
+
+namespace MDUC_BE.Application.Services;
+
+public class AddressService
+{
+    private readonly SonarGraphQLClient _client;
+    public AddressService(SonarGraphQLClient client) => _client = client;
+
+    public Task<IEnumerable<AddressDto>> GetByLine1Async(string line1, CancellationToken ct = default) => _client.GetAddressesByLine1Async(line1, ct);
+}

--- a/Common/Errors/ApiErrorCode.cs
+++ b/Common/Errors/ApiErrorCode.cs
@@ -1,0 +1,9 @@
+namespace MDUC_BE.Common.Errors;
+
+public static class ApiErrorCode
+{
+    public const string Validation = "validation_error";
+    public const string Unauthorized = "unauthorized";
+    public const string UpstreamError = "upstream_error";
+    public const string Unexpected = "unexpected_error";
+}

--- a/Common/Models/ErrorResponse.cs
+++ b/Common/Models/ErrorResponse.cs
@@ -1,0 +1,3 @@
+namespace MDUC_BE.Common.Models;
+
+public record ErrorResponse(string TraceId, string ErrorCode, string Message, object? Details);

--- a/Infrastructure/GraphQL/GraphQLModels.cs
+++ b/Infrastructure/GraphQL/GraphQLModels.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace MDUC_BE.Infrastructure.GraphQL;
+
+public class GraphQLRequest
+{
+    [JsonPropertyName("query")]
+    public string Query { get; set; } = string.Empty;
+
+    [JsonPropertyName("operationName")]
+    public string? OperationName { get; set; }
+
+    [JsonPropertyName("variables")]
+    public object? Variables { get; set; }
+}
+
+public class GraphQLResponse<T>
+{
+    [JsonPropertyName("data")]
+    public T? Data { get; set; }
+
+    [JsonPropertyName("errors")]
+    public GraphQLError[]? Errors { get; set; }
+}
+
+public class GraphQLError
+{
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+}

--- a/Infrastructure/GraphQL/SonarGraphQLClient.cs
+++ b/Infrastructure/GraphQL/SonarGraphQLClient.cs
@@ -1,0 +1,110 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using MDUC_BE.Api.Models;
+
+namespace MDUC_BE.Infrastructure.GraphQL;
+
+public class SonarGraphQLClient
+{
+    private readonly HttpClient _client;
+    private readonly ILogger<SonarGraphQLClient> _logger;
+
+    public SonarGraphQLClient(HttpClient client, IConfiguration configuration, ILogger<SonarGraphQLClient> logger)
+    {
+        _client = client;
+        _logger = logger;
+
+        var baseUrl = configuration["Sonar:GraphQLUrl"];
+        if (!string.IsNullOrEmpty(baseUrl))
+        {
+            _client.BaseAddress = new Uri(baseUrl);
+        }
+
+        var apiKey = configuration["Sonar:ApiKey"];
+        if (!string.IsNullOrEmpty(apiKey))
+        {
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        }
+    }
+
+    public async Task<T?> SendAsync<T>(string query, object? variables = null, string? operationName = null, CancellationToken ct = default)
+    {
+        var request = new GraphQLRequest
+        {
+            Query = query,
+            Variables = variables,
+            OperationName = operationName
+        };
+
+        using var response = await _client.PostAsJsonAsync(string.Empty, request, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Sonar returned status {StatusCode}", response.StatusCode);
+            throw new HttpRequestException($"Sonar error {(int)response.StatusCode}");
+        }
+
+        var gql = await response.Content.ReadFromJsonAsync<GraphQLResponse<T>>(cancellationToken: ct);
+        if (gql?.Errors?.Any() == true)
+        {
+            var messages = string.Join(";", gql.Errors.Select(e => e.Message));
+            _logger.LogError("GraphQL errors: {Errors}", messages);
+            throw new Exception(messages);
+        }
+
+        return gql?.Data;
+    }
+
+    public virtual async Task<IEnumerable<AddressDto>> GetAddressesByLine1Async(string line1, CancellationToken ct = default)
+    {
+        const string query = @"query ServiceableAddresses($line1: String!) {
+  addresses(serviceable:true, type:PHYSICAL, general_search:$line1) {
+    entities {
+      id
+      line1
+      line2
+      city
+      subdivision
+      zip
+      country
+      latitude
+      longitude
+      serviceable
+      addressable_type
+    }
+  }
+}";
+
+        var result = await SendAsync<AddressSearchData>(query, new { line1 }, "ServiceableAddresses", ct);
+        return result?.Addresses.Entities ?? Enumerable.Empty<AddressDto>();
+    }
+
+    public virtual async Task<CreateAccountResponse?> CreateAccountAsync(CreateAccountRequest input, CancellationToken ct = default)
+    {
+        const string mutation = @"mutation CreateAccount($input: CreateAccountInput!) {
+  createAccount(input:$input) {
+    id
+    name
+  }
+}";
+
+        var variables = new
+        {
+            input = new
+            {
+                name = input.Name,
+                account_type_id = input.AccountTypeId,
+                account_status_id = input.AccountStatusId,
+                serviceable_address_id = input.ServiceableAddressId,
+                primary_contact = new { name = input.PrimaryContactName }
+                // TODO: Adjust to Sonar schema
+            }
+        };
+
+        var result = await SendAsync<CreateAccountPayload>(mutation, variables, "CreateAccount", ct);
+        return result?.CreateAccount;
+    }
+
+    private record AddressSearchData(AddressCollection Addresses);
+    private record AddressCollection(IEnumerable<AddressDto> Entities);
+    private record CreateAccountPayload(CreateAccountResponse CreateAccount);
+}

--- a/MDUC_BE.csproj
+++ b/MDUC_BE.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Polly.Extensions.Http" Version="7.2.3" />
+    <PackageReference Include="FluentValidation" Version="11.9.3" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.3" />
+  </ItemGroup>
+
+</Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,86 @@
+using MDUC_BE.Api.Endpoints;
+using MDUC_BE.Api.Middleware;
+using MDUC_BE.Application.Services;
+using MDUC_BE.Infrastructure.GraphQL;
+using System.Net.Http;
+using Polly;
+using Polly.Extensions.Http;
+using Serilog;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((ctx, cfg) =>
+{
+    cfg.ReadFrom.Configuration(ctx.Configuration)
+       .WriteTo.Console()
+       .WriteTo.File("logs/log.txt", rollingInterval: RollingInterval.Day);
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new() { Title = "Sonar Proxy API", Version = "v1" });
+    c.AddSecurityDefinition("ApiKey", new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+    {
+        Name = "X-API-Key",
+        In = Microsoft.OpenApi.Models.ParameterLocation.Header,
+        Type = Microsoft.OpenApi.Models.SecuritySchemeType.ApiKey
+    });
+    c.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement
+    {
+        {
+            new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+            {
+                Reference = new Microsoft.OpenApi.Models.OpenApiReference
+                {
+                    Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme,
+                    Id = "ApiKey"
+                }
+            }, new string[] {}
+        }
+    });
+});
+
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.WithOrigins(allowedOrigins).AllowAnyHeader().AllowAnyMethod());
+});
+
+builder.Services.AddHttpClient<SonarGraphQLClient>()
+    .AddPolicyHandler(GetRetryPolicy())
+    .AddPolicyHandler(GetCircuitBreakerPolicy())
+    .AddPolicyHandler(Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(10)));
+
+builder.Services.AddScoped<AddressService>();
+builder.Services.AddScoped<AccountService>();
+
+var app = builder.Build();
+
+app.UseSerilogRequestLogging();
+app.UseGlobalErrorHandler();
+app.UseCors();
+app.UseApiKey();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+var api = app.MapGroup("/api");
+api.MapAddressEndpoints();
+api.MapAccountEndpoints();
+
+app.Run();
+
+static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy() =>
+    HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(Math.Pow(2, retry)));
+
+static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy() =>
+    HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .CircuitBreakerAsync(5, TimeSpan.FromSeconds(30));

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5083",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7159;http://localhost:5083",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# MDUC_BE
+# Sonar GraphQL Proxy
+
+Minimal API using .NET 9 that proxies requests to the Sonar GraphQL API. It exposes a small surface area ready to expand.
+
+## Configuration
+
+Values can be stored in `appsettings.json`, environment variables or user-secrets:
+
+- `Sonar:GraphQLUrl` – e.g. `https://<host>/graphql`.
+- `Sonar:ApiKey` – server-side Sonar API key.
+- `PublicApiKey` – value expected in `X-API-Key` header.
+- `Cors:AllowedOrigins` – array of origins allowed by CORS.
+
+## Running
+
+```bash
+dotnet run
+```
+
+## Testing
+
+```bash
+dotnet test
+```
+
+## Endpoints
+
+- `GET /api/addresses?line1={text}` – search serviceable addresses.
+- `POST /api/account` – create a new account.
+
+## Notes
+
+GraphQL query and mutation fields are placeholders. Adjust the schema sections in `SonarGraphQLClient` to match the actual Sonar API.

--- a/Tests/Integration/AddressEndpointTests.cs
+++ b/Tests/Integration/AddressEndpointTests.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MDUC_BE.Api.Models;
+using MDUC_BE.Infrastructure.GraphQL;
+using MDUC_BE;
+
+namespace MDUC_BE.Tests.Integration;
+
+public class AddressEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public AddressEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var mock = new Mock<SonarGraphQLClient>(new HttpClient(), Mock.Of<IConfiguration>(), Mock.Of<ILogger<SonarGraphQLClient>>());
+                mock.Setup(c => c.GetAddressesByLine1Async("abc", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new[] { new AddressDto("1","A",null,"City",null,"Zip","Country",null,null,true,"PHYSICAL") });
+
+                services.AddSingleton(mock.Object);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task GetAddresses_ReturnsOk()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", "PUBLIC_API_KEY_PLACEHOLDER");
+
+        var response = await client.GetAsync("/api/addresses?line1=abc");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/Tests/MDUC_BE.Tests.csproj
+++ b/Tests/MDUC_BE.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MDUC_BE.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Unit/AddressServiceTests.cs
+++ b/Tests/Unit/AddressServiceTests.cs
@@ -1,0 +1,22 @@
+using Moq;
+using MDUC_BE.Api.Models;
+using MDUC_BE.Application.Services;
+using MDUC_BE.Infrastructure.GraphQL;
+
+namespace MDUC_BE.Tests.Unit;
+
+public class AddressServiceTests
+{
+    [Fact]
+    public async Task GetByLine1Async_ReturnsFromClient()
+    {
+        var expected = new[] { new AddressDto("1","A","B","City",null,"Zip","Country",null,null,true,"PHYSICAL") };
+        var client = new Mock<SonarGraphQLClient>(new HttpClient(), Mock.Of<IConfiguration>(), Mock.Of<ILogger<SonarGraphQLClient>>());
+        client.Setup(c => c.GetAddressesByLine1Async("abc", It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+        var service = new AddressService(client.Object);
+
+        var result = await service.GetByLine1Async("abc");
+
+        Assert.Single(result);
+    }
+}

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Sonar": {
+    "GraphQLUrl": "https://<host>/graphql",
+    "ApiKey": "SONAR_API_KEY_PLACEHOLDER"
+  },
+  "PublicApiKey": "PUBLIC_API_KEY_PLACEHOLDER",
+  "Cors": {
+    "AllowedOrigins": [
+      "https://localhost:3000"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- implement minimal .NET 9 API proxying Sonar GraphQL
- add API key middleware, error handling, CORS, Swagger and Serilog
- provide GraphQL client, application services, endpoints and tests

## Testing
- `dotnet test` *(fails: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b15a513c8330b41459d87d393193